### PR TITLE
fixed <malloc.h> to <stdlib.h>

### DIFF
--- a/src/func/approx.c
+++ b/src/func/approx.c
@@ -1,7 +1,7 @@
-#include <malloc.h>
-#include <stdio.h>
 #include "approx.h"
 #include "rotater.h"
+#include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #define reset rec->r->start = rStart; rec->r->end = rEnd; rec->patIndex=patIndex; rec->patChar = com->pattern[rec->patIndex]; rec->editIndex = editIndex; rec->editAmount = editA;
 #define forAlphabet(code) for(int sym=1; sym<5; sym++) {code(sym, rec, com); reset;} //This is weird, I love it!

--- a/src/func/helper.c
+++ b/src/func/helper.c
@@ -1,12 +1,11 @@
 #include "helper.h"
-#include <stdio.h>
-#include <malloc.h>
-#include <string.h>
-#include <stdlib.h>
-#include "parsers/simple-fastq-parser.h"
-#include "parsers/simple-fasta-parser.h"
-#include "rotater.h"
 #include "approx.h"
+#include "parsers/simple-fasta-parser.h"
+#include "parsers/simple-fastq-parser.h"
+#include "rotater.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 void printIntArray(int * a, int len) {
     printf("[");

--- a/src/func/parsers/simple-fasta-parser.c
+++ b/src/func/parsers/simple-fasta-parser.c
@@ -1,5 +1,5 @@
 #include <ctype.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "simple-fasta-parser.h"
 
 

--- a/src/func/rotater.c
+++ b/src/func/rotater.c
@@ -1,7 +1,7 @@
-#include <malloc.h>
 #include "rotater.h"
-#include <stdio.h>
 #include "helper.h"
+#include <stdio.h>
+#include <stdlib.h>
 
 void makeOandC(const int* bwt, int n, int** O, int* C, int alphabetSize) {
 

--- a/src/func/sa.c
+++ b/src/func/sa.c
@@ -1,6 +1,6 @@
 #include "sa.h"
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 
 int *constructSARadix(struct Fasta fasta, int reverse) {

--- a/src/readmap.c
+++ b/src/readmap.c
@@ -1,11 +1,9 @@
+#include "func/helper.h"
+#include "func/parsers/simple-fasta-parser.h"
+#include "func/sa.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
-#include "func/sa.h"
-#include "func/helper.h"
-#include "func/parsers/simple-fasta-parser.h"
-
 
 static void print_usage(const char *progname)
 {

--- a/test/testHelper.h
+++ b/test/testHelper.h
@@ -1,6 +1,6 @@
 #ifndef SA_TESTHELPER_H
 #define SA_TESTHELPER_H
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 char *test_data_path;

--- a/test/time.c
+++ b/test/time.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "../src/func/parsers/simple-fasta-parser.h"
 #include "../src/func/helper.h"
 #include "../src/func/sa.h"


### PR DESCRIPTION
Jeg har fikset der hvor I inkluderer `malloc.h`. Det er en gammel og for mange år siden udfaset måde at få `malloc()` ind på. Standarden siden C99 har været `<stdlib.h>`.